### PR TITLE
feat: incremental loading of album contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Platform | Name | Description
 `camera` | `media` | An image from the Google Photos Album.
 `sensor` | `filename` | Filename of the currently selected media item.
 `sensor` | `creation_timestamp` | Timestamp of the currently selected media item.
-`sensor` | `media_count` | Counter showing the number of media items in the album (photo + video).
+`sensor` | `media_count` | Counter showing the number of media items in the album (photo + video). It could take a while to populate all media items, to check if the integration is still loading an attribute `is_updating` is available.
 `select` | `image_selection_mode` | Configuration setting on how to pick the next image.
 `select` | `crop_mode` | Configuration setting on how to crop the image, either `Original`, `Crop` or `Combine images` [(explanation)](#crop-modes).
 `select` | `update_interval` | Configuration setting on how often to update the image, if you have a lot of albums running on your instance it is adviseable to not set this to low.
@@ -144,11 +144,11 @@ data:
 
 ## Notes / Remarks / Limitations
 
-- Currently the album media list is cached for 50 minutes.
+- Currently the album media list is cached for 3 hours.
+- Directly after loading the integration / starting HA, the album will only contain 100 items. This is done to reduce server load on the Google Photos servers, every 30 seconds a new batch of media is requested.
 
 ## Future plans
-
-- Reduce start-up time integration (currently loads entire album which can be slow)
+- Give end user more control over album cache time
 - Support for videos
 - Support loading media using [content categories](https://developers.google.com/photos/library/guides/apply-filters#content-categories)
 - Support loading media filtered by date/time

--- a/custom_components/google_photos/api_types.py
+++ b/custom_components/google_photos/api_types.py
@@ -52,15 +52,20 @@ class MediaMetadata(TypedDict):
     video: Optional[MediaMetadataVideo]
 
 
-class MediaItem(TypedDict):
-    """Representation of a media item (such as a photo or video) in Google Photos."""
+class MediaListItem(TypedDict):
+    """Representation of a media item (such as a photo or video) as part of a list in Google Photos."""
 
     id: str
+    mediaMetadata: Optional[MediaMetadata]
+
+
+class MediaItem(MediaListItem):
+    """Representation of a media item (such as a photo or video) in Google Photos."""
+
     description: str
     productUrl: str
     baseUrl: str
     mimeType: str
-    mediaMetadata: Optional[MediaMetadata]
     contributorInfo: Optional[MediaContributorInfo]
     filename: str
 

--- a/custom_components/google_photos/camera.py
+++ b/custom_components/google_photos/camera.py
@@ -129,13 +129,13 @@ class GooglePhotosBaseCamera(Camera):
 
     def next_media(self, mode=None):
         """Load the next media."""
-        self.coordinator.select_next(mode)
+        self.hass.async_add_job(self.coordinator.select_next(mode))
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None
     ) -> bytes | None:
         """Return a still image response from the camera."""
-        self.coordinator.refresh_current_image()
+        await self.coordinator.refresh_current_image()
         if self.coordinator.current_media is None:
             _LOGGER.warning("No media selected for %s", self.name)
             return None

--- a/custom_components/google_photos/coordinator.py
+++ b/custom_components/google_photos/coordinator.py
@@ -414,7 +414,12 @@ class AlbumDownloader:
     _auth: AsyncConfigEntryAuth
     _hass: HomeAssistant
     _items_per_page = 100
-    _content_refresh_interval = timedelta(hours=3)
+    _content_refresh_interval = timedelta(
+        hours=3,
+        minutes=random.randint(
+            0, 15
+        ),  # Randomize a bit to avoid all albums updating simultaneously
+    )
     _loading = False
     _last_page_token = None
     _current_page_offset = 0

--- a/custom_components/google_photos/coordinator.py
+++ b/custom_components/google_photos/coordinator.py
@@ -1,7 +1,7 @@
 """Coordinators to fetch data for all entities"""
 from __future__ import annotations
 import asyncio
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import logging
 import math
@@ -24,7 +24,7 @@ from PIL import Image
 import io
 
 from .api import AsyncConfigEntryAuth
-from .api_types import Album, MediaItem, PhotosLibraryService
+from .api_types import Album, MediaItem, MediaListItem, PhotosLibraryService
 from .const import (
     CONF_ALBUM_ID_FAVORITES,
     DOMAIN,
@@ -89,17 +89,14 @@ class Coordinator(DataUpdateCoordinator):
 
     _auth: AsyncConfigEntryAuth
     _config: ConfigEntry
-    _context: dict[str, str | int] = dict()
+
     album: Album = None
     album_id: str
-    album_list: List[MediaItem] = []
+    album_contents: AlbumDownloader
     current_media_primary: MediaDownloader | None = None
     current_media_secondary: MediaDownloader | None = None
-
     current_media_cache: Dict[str, bytes] = {}
 
-    # Timestamop when these items where loaded
-    album_list_timestamp = datetime.fromtimestamp(0)
     # Media selection timestamp, when was this image selected to be shown,
     # used to calculate when to move to the next one
     current_media_selected_timestamp = datetime.fromtimestamp(0)
@@ -129,13 +126,15 @@ class Coordinator(DataUpdateCoordinator):
 
         if self.album_id == CONF_ALBUM_ID_FAVORITES:
             filters = {"featureFilter": {"includedFeatures": ["FAVORITES"]}}
-            self.set_context(dict(filters=filters))
+            context = dict(filters=filters)
             self.album = Album(id=self.album_id, title="Favorites", isWriteable=False)
         else:
-            self.set_context(dict(albumId=self.album_id))
+            context = dict(albumId=self.album_id)
+        self.album_contents = AlbumDownloader(hass, auth, context)
 
     @property
     def current_media(self) -> MediaItem | None:
+        """Get current media item"""
         if self.current_media_primary is None:
             return None
         return self.current_media_primary.media
@@ -154,10 +153,6 @@ class Coordinator(DataUpdateCoordinator):
             name="Google Photos - " + self.album.get("title"),
             configuration_url=self.album.get("productUrl", None),
         )
-
-    def set_context(self, context: dict[str, str | int]):
-        """Set coordinator context"""
-        self._context = context
 
     def set_crop_mode(self, crop_mode: str):
         """Set crop mode"""
@@ -178,24 +173,6 @@ class Coordinator(DataUpdateCoordinator):
             return self._config.options[prop]
         return default
 
-    def photo_media_list(self) -> List[MediaItem]:
-        """Get photos from media list"""
-        return list(
-            filter(
-                lambda m: (m.get("mediaMetadata") or {}).get("photo") is not None,
-                self.album_list,
-            )
-        )
-
-    def video_media_list(self) -> List[MediaItem]:
-        """Get videos from media list"""
-        return list(
-            filter(
-                lambda m: (m.get("mediaMetadata") or {}).get("video") is not None,
-                self.album_list,
-            )
-        )
-
     def current_media_id(self) -> str | None:
         """Id of current media"""
         media = self.current_media
@@ -203,33 +180,28 @@ class Coordinator(DataUpdateCoordinator):
             return None
         return media.get("id")
 
-    async def set_current_media_with_id(self, media_id: str):
+    async def set_current_media_with_id(self, media_id: str | None):
         """Sets current selected media using only the id"""
+        if media_id is None:
+            return
         try:
-            service = await self._auth.get_resource(self.hass)
-
-            def _get_media_item() -> MediaItem:
-                return service.mediaItems().get(mediaItemId=media_id).execute()
-
-            self.set_current_media(
-                await self.hass.async_add_executor_job(_get_media_item)
+            media = await self._get_media_by_id(media_id)
+            self.current_media_primary = MediaDownloader(
+                self.hass, self._auth, media, datetime.now()
             )
+            self.current_media_secondary = None
+            self.current_media_cache = {}
+            self.current_media_selected_timestamp = datetime.now()
+            self.async_update_listeners()
         except aiohttp.ClientError as err:
-            _LOGGER.error("Error getting image from %s: %s", self._context, err)
+            _LOGGER.error(
+                "Error getting image from %s: %s", self.album_contents.context, err
+            )
 
-    def set_current_media(self, media: MediaItem):
-        """Sets current selected media"""
-        self.current_media_primary = MediaDownloader(
-            self.hass, self._auth, media, self.album_list_timestamp
-        )
-        self.current_media_secondary = None
-        self.current_media_cache = {}
-        self.current_media_selected_timestamp = datetime.now()
-        self.async_update_listeners()
-
-    def refresh_current_image(self) -> bool:
+    async def refresh_current_image(self) -> bool:
         """Selects next image if interval has passed"""
-        self.hass.async_add_job(self._refresh_album_list)
+        if self.album_contents.requires_refresh:
+            self.hass.async_add_job(self.async_request_refresh)
         interval = SETTING_INTERVAL_MAP.get(self.interval)
         if interval is None:
             return False
@@ -238,27 +210,28 @@ class Coordinator(DataUpdateCoordinator):
             datetime.now() - self.current_media_selected_timestamp
         ).total_seconds()
         if time_delta > interval or self.current_media is None:
-            self.select_next()
+            await self.select_next()
             return True
         return False
 
-    def select_next(self, mode=None):
+    async def select_next(self, mode=None):
         """Select next media based on config"""
         mode = mode or self.image_selection_mode
         if mode.lower() == SETTING_IMAGESELECTION_MODE_ALBUM_ORDER.lower():
-            self.select_sequential_media()
+            await self._select_sequential_media()
         else:
-            self.select_random_media()
+            await self._select_random_media()
 
-    def select_random_media(self):
+    async def _select_random_media(self):
         """Selects a random media item from the list"""
-        media_list = self.photo_media_list()
+        media_list = self.album_contents.photo_media_list()
         if len(media_list) > 1:
-            self.set_current_media(random.choice(media_list))
+            item = random.choice(media_list)
+            await self.set_current_media_with_id(item.get("id"))
 
-    def select_sequential_media(self):
+    async def _select_sequential_media(self):
         """Finds the current photo in the list, and moves to the next"""
-        media_list = self.photo_media_list()
+        media_list = self.album_contents.photo_media_list()
         if len(media_list) < 1:
             return
         current_index = -1
@@ -269,7 +242,8 @@ class Coordinator(DataUpdateCoordinator):
                 break
         current_index = current_index + 1
         current_index = current_index % len(media_list)
-        self.set_current_media(media_list[current_index])
+        item = media_list[current_index]
+        await self.set_current_media_with_id(item.get("id"))
 
     async def get_media_data(self, width: int | None = None, height: int | None = None):
         """Get a binary image data for the current media"""
@@ -322,13 +296,16 @@ class Coordinator(DataUpdateCoordinator):
                     is media_is_portrait
                 )
                 and (m.get("id") != self.current_media_id()),
-                self.photo_media_list(),
+                self.album_contents.photo_media_list(),
             )
             secondary_media = random.choice(list(similar_orientation_images))
             if secondary_media is None:
                 return None
             self.current_media_secondary = MediaDownloader(
-                self.hass, self._auth, secondary_media, self.album_list_timestamp
+                self.hass,
+                self._auth,
+                await self._get_media_by_id(secondary_media.get("id")),
+                datetime.now(),
             )
 
         size_str = (
@@ -361,9 +338,18 @@ class Coordinator(DataUpdateCoordinator):
                 output.save(result, "JPEG")
                 return result.getvalue()
 
+    async def _get_media_by_id(self, media_id: str | None) -> MediaItem:
+        service = await self._auth.get_resource(self.hass)
+
+        def _get_media_item() -> MediaItem:
+            return service.mediaItems().get(mediaItemId=media_id).execute()
+
+        return await self.hass.async_add_executor_job(_get_media_item)
+
     async def update_data(self):
         """Check if media list or current image needs to be refreshed"""
-        await self._refresh_album_list()
+        await self.album_contents.refresh_album_list()
+        self.update_interval = self.album_contents.update_interval
 
     def _is_portrait(self, dimensions: Tuple[float, float]) -> bool:
         """Returns if the given dimension represent a portrait media item"""
@@ -403,38 +389,6 @@ class Coordinator(DataUpdateCoordinator):
             return None
         return (float(width), float(height))
 
-    async def _get_album_list(self):
-        try:
-            service = await self._auth.get_resource(self.hass)
-            search_query = self._context.copy()
-            search_query["pageSize"] = 100
-
-            def sync_get_album_list() -> List[MediaItem]:
-                result = service.mediaItems().search(body=search_query).execute()
-                if not "mediaItems" in result:
-                    return []
-
-                album_list = result["mediaItems"]
-                while "nextPageToken" in result and result["nextPageToken"] != "":
-                    search_query["pageToken"] = result["nextPageToken"]
-                    result = service.mediaItems().search(body=search_query).execute()
-                    album_list = album_list + result["mediaItems"]
-                return album_list
-
-            self.album_list = await self.hass.async_add_executor_job(
-                sync_get_album_list
-            )
-            self.album_list_timestamp = datetime.now()
-        except aiohttp.ClientError as err:
-            _LOGGER.error("Error getting media lise from %s: %s", self._context, err)
-
-    async def _refresh_album_list(self) -> bool:
-        cache_delta = (datetime.now() - self.album_list_timestamp).total_seconds()
-        if cache_delta < FIFTY_MINUTES:
-            return False
-        await self._get_album_list()
-        return True
-
     async def _async_update_data(self):
         """Fetch album data"""
 
@@ -452,6 +406,134 @@ class Coordinator(DataUpdateCoordinator):
                 await self.update_data()
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+
+class AlbumDownloader:
+    """Utility class for downloading the album contents"""
+
+    _auth: AsyncConfigEntryAuth
+    _hass: HomeAssistant
+    _items_per_page = 100
+    _content_refresh_interval = timedelta(hours=3)
+    _loading = False
+    _last_page_token = None
+    _current_page_offset = 0
+
+    album_list: List[MediaListItem] = []
+    context: dict[str, str | int]
+    update_interval: timedelta | None
+
+    # Timestamp when these items where loaded
+    album_list_timestamp = datetime.fromtimestamp(0)
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        auth: AsyncConfigEntryAuth,
+        context: dict[str, str | int],
+    ) -> None:
+        self._hass = hass
+        self._auth = auth
+        self.context = context
+
+    async def _get_album_list(self):
+        """This function will incrementally load the media list to avoid overloading the google servers. To avoid the media list being emptied every refresh interval, contents are replaced in place."""
+        try:
+            if self._loading:
+                return
+            self._loading = True
+
+            # Limit the amount of items that are requested on each load so we don't bash the servers to much
+            loop_limit = 300
+
+            if self._last_page_token is None:
+                # If the token is None, we are building the media list from scratch
+                self._current_page_offset = 0
+                # First request, only load the first 100 to speed up integration load times
+                loop_limit = 100
+
+            service = await self._auth.get_resource(self._hass)
+            search_query = self.context.copy()
+            fields = "mediaItems(id,mediaMetadata(photo,video)),nextPageToken"
+            search_query["pageSize"] = self._items_per_page
+
+            def sync_get_album_list() -> List[MediaListItem]:
+                current_size = 0
+                while current_size < loop_limit:
+                    search_query["pageToken"] = self._last_page_token
+                    result = (
+                        service.mediaItems()
+                        .search(body=search_query, fields=fields)
+                        .execute()
+                    )
+                    if not "mediaItems" in result:
+                        return
+
+                    self._last_page_token = result.get("nextPageToken")
+                    result_count = len(result.get("mediaItems"))
+                    # Overwrite array slice with new items
+                    self.album_list[
+                        self._current_page_offset : (
+                            self._current_page_offset + result_count
+                        )
+                    ] = result.get("mediaItems")
+                    self._current_page_offset += result_count
+                    current_size += result_count
+                    if self._last_page_token is None:
+                        break
+
+            await self._hass.async_add_executor_job(sync_get_album_list)
+
+            if self._last_page_token is None:
+                # No token in last result, we are done loading!
+                self.album_list_timestamp = datetime.now()
+                self.update_interval = None
+                self.album_list = self.album_list[0 : self._current_page_offset]
+            else:
+                self.update_interval = timedelta(seconds=30)
+
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Error getting media list from %s: %s", self.context, err)
+
+        finally:
+            self._loading = False
+
+    async def refresh_album_list(self) -> bool:
+        """Check if content requires refresh"""
+        if not self.requires_refresh:
+            self.update_interval = None
+            return False
+        await self._get_album_list()
+        return True
+
+    def photo_media_list(self) -> List[MediaListItem]:
+        """Get photos from media list"""
+        return list(
+            filter(
+                lambda m: (m.get("mediaMetadata") or {}).get("photo") is not None,
+                self.album_list,
+            )
+        )
+
+    def video_media_list(self) -> List[MediaListItem]:
+        """Get videos from media list"""
+        return list(
+            filter(
+                lambda m: (m.get("mediaMetadata") or {}).get("video") is not None,
+                self.album_list,
+            )
+        )
+
+    @property
+    def requires_refresh(self) -> bool:
+        """Does the content require a refresh"""
+        cache_delta = datetime.now() - self.album_list_timestamp
+        return cache_delta > self._content_refresh_interval
+
+    @property
+    def is_building_list(self) -> bool:
+        """Is the media list still being downloaded"""
+        return self._last_page_token is not None
 
 
 class MediaDownloader:

--- a/custom_components/google_photos/select.py
+++ b/custom_components/google_photos/select.py
@@ -76,8 +76,9 @@ class GooglePhotosSelectCropMode(SelectEntity, RestoreEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        self.coordinator.set_crop_mode(option)
-        self.async_write_ha_state()
+        if option is not self.coordinator.crop_mode:
+            self.coordinator.set_crop_mode(option)
+            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
@@ -124,8 +125,9 @@ class GooglePhotosSelectImageSelectionMode(SelectEntity, RestoreEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        self.coordinator.set_image_selection_mode(option)
-        self.async_write_ha_state()
+        if option is not self.coordinator.image_selection_mode:
+            self.coordinator.set_image_selection_mode(option)
+            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
@@ -174,8 +176,9 @@ class GooglePhotosSelectInterval(SelectEntity, RestoreEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        self.coordinator.set_interval(option)
-        self.async_write_ha_state()
+        if option is not self.coordinator.interval:
+            self.coordinator.set_interval(option)
+            self.async_write_ha_state()
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/custom_components/google_photos/sensor.py
+++ b/custom_components/google_photos/sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorEntityDescription,
     SensorDeviceClass,
+    SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -165,7 +166,11 @@ class GooglePhotosMediaCount(SensorEntity):
         album_id = self.coordinator.album["id"]
         self._attr_device_info = self.coordinator.get_device_info()
         self._attr_unique_id = f"{album_id}-mediacount"
-        self._attr_native_value = len(self.coordinator.album_list)
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_native_value = len(self.coordinator.album_contents.album_list)
+        self._attr_extra_state_attributes = {
+            "is_updating": self.coordinator.album_contents.is_building_list
+        }
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -187,5 +192,8 @@ class GooglePhotosMediaCount(SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = len(self.coordinator.album_list)
+        self._attr_native_value = len(self.coordinator.album_contents.album_list)
+        self._attr_extra_state_attributes[
+            "is_updating"
+        ] = self.coordinator.album_contents.is_building_list
         self.async_write_ha_state()


### PR DESCRIPTION
Resolves #11.

Adds incremental loading of album contents:
- When the integration starts, the first 100 items are loaded.
- Afterwards an additional 300 items are loaded every 30 seconds.
- Every 3 hours, the integration checks for new items.

This avoids timeouts and rate limits from the Google server whilst still refreshing the album contents with new content on a interval.

