### PR TITLE
fix: match pillow version with whatever HA is using, fixes 2023.8 startup issue.

### DIFF
--- a/custom_components/google_photos/manifest.json
+++ b/custom_components/google_photos/manifest.json
@@ -16,7 +16,7 @@
   ],
   "requirements": [
     "google-api-python-client>=2.71.0",
-    "pillow>=9.1.1,<10.0.0"
+    "pillow"
   ],
   "version": "v0.0.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pip>=21.0,<23.1
 colorlog
 homeassistant
 google-api-python-client==2.71.0
-pillow==9.4.0
+pillow


### PR DESCRIPTION
Fixes #35 