### PR TITLE
fix: Error calling next_media after core update 2024.5.0 #48

### DIFF
--- a/custom_components/google_photos/camera.py
+++ b/custom_components/google_photos/camera.py
@@ -130,9 +130,9 @@ class GooglePhotosBaseCamera(Camera):
             )
             self.async_write_ha_state()
 
-    def next_media(self, mode=None):
+    async def next_media(self, mode=None):
         """Load the next media."""
-        self.hass.async_add_job(self.coordinator.select_next(mode))
+        await self.coordinator.select_next(mode)
 
     async def async_camera_image(
         self, width: int | None = None, height: int | None = None


### PR DESCRIPTION
Fixes #48 : 
```
2024-05-01 23:54:52.984 WARNING (SyncWorker_0) [homeassistant.helpers.frame] Detected that custom integration 'google_photos' calls async_create_task from a thread at custom_components/google_photos/camera.py, line 135: self.hass.async_add_job(self.coordinator.select_next(mode)), please report it to the author of the 'google_photos' custom integration
```